### PR TITLE
Homebrew command change

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ This is a simple QuickLook plugin to browse GeoJSON and TopoJSON files.
 
 This QuickLook Plugin can now be installed using [Homebrew Cask](https://github.com/caskroom/homebrew-cask):
 
-> homebrew cask install quickgeojson
+```bash
+brew install --cask quickgeojson
+```
 
 ### Installation Instructions
 


### PR DESCRIPTION
Homebrew has changed the way cask commands are issued to `brew install --cask` ([homepage example](https://brew.sh/#:~:text=%24-,brew%20install%20%2D%2Dcask,-firefox)). I've updated the README to reflect this.